### PR TITLE
Create new onboarding page with inertia

### DIFF
--- a/airdrop-viral-app/backend/resources/js/Pages/Onboarding/FirstScreen.vue
+++ b/airdrop-viral-app/backend/resources/js/Pages/Onboarding/FirstScreen.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-primary-50 to-primary-100 px-4 py-12">
+    <h1 class="text-4xl font-bold text-center mb-12">Unlock your perfect job</h1>
+
+    <div class="w-full max-w-md space-y-6">
+      <!-- Yes Option -->
+      <div
+        @click="selectOption('yes')"
+        class="card cursor-pointer transition-transform hover:-translate-y-1 active:translate-y-0.5"
+      >
+        <p class="text-lg font-semibold text-center">Yes, I live in the United States</p>
+      </div>
+
+      <!-- No Option -->
+      <div
+        @click="selectOption('no')"
+        class="card cursor-pointer transition-transform hover:-translate-y-1 active:translate-y-0.5"
+      >
+        <p class="text-lg font-semibold text-center">No, I live outside the United States</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { router } from '@inertiajs/vue3'
+
+/**
+ * Handle option selection.
+ * For now we simply redirect to a placeholder next step which will be implemented later.
+ * The chosen value is passed along as a query parameter so that the next step can make use of it.
+ */
+function selectOption(choice) {
+  router.visit(`/onboarding/step2`, {
+    data: { usResident: choice },
+    method: 'get',
+  })
+}
+</script>

--- a/airdrop-viral-app/backend/routes/web.php
+++ b/airdrop-viral-app/backend/routes/web.php
@@ -55,3 +55,7 @@ Route::get('/analytics/{shortCode}', function ($shortCode) {
         'profileCode' => $shortCode,
     ]);
 })->name('profile.analytics');
+
+Route::get('/onboarding', function () {
+    return Inertia::render('Onboarding/FirstScreen');
+})->name('onboarding');


### PR DESCRIPTION
Add the first screen of the new, unauthenticated onboarding flow at `/onboarding`.

---
<a href="https://cursor.com/background-agent?bcId=bc-877c58eb-3988-4928-9dc2-1d0e300753d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-877c58eb-3988-4928-9dc2-1d0e300753d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>